### PR TITLE
fix: remove unused toast import causing Netlify build failure

### DIFF
--- a/src/components/admin/AdminItens.tsx
+++ b/src/components/admin/AdminItens.tsx
@@ -1,6 +1,5 @@
 import { Edit2, ExternalLink, Loader2, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
-import toast from "react-hot-toast";
 import ItemModal from "../ItemModal";
 import { useAdminItems } from "../../hooks/useAdminItems";
 import type { CreateItemRequest, Item } from "../../types";


### PR DESCRIPTION
## Summary
- Remove unused `toast` import from `AdminItens.tsx` that was causing TypeScript error TS6133
- This was blocking the Netlify production build with exit code 2

## Test plan
- [ ] Verify Netlify build passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)